### PR TITLE
[METADATA UPDATE] Global metadata changes

### DIFF
--- a/officedocs-dev-exchange-ews-proxy/docfx.json
+++ b/officedocs-dev-exchange-ews-proxy/docfx.json
@@ -39,6 +39,8 @@
       ]
     },
     "globalMetadata": {
+      "ms.subservice": "exchange-web-services",
+      "ms.service": "exchange",
       "apiPlatform": "dotnet",
       "breadcrumb_path": "~/breadcrumb/toc.yml",
       "ROBOTS": "INDEX,FOLLOW",
@@ -48,12 +50,10 @@
       "ms.devlang": "dotnet",
       "audience": "developer",
       "ms.suite": "office",
-      "ms.prod": "exchange",
       "products": [
         "https://authoring-docs-microsoft.poolparty.biz/devrel/390894b2-8646-4f7e-b8cd-2209156272a9",
         "https://authoring-docs-microsoft.poolparty.biz/devrel/6ab06385-661e-4214-8870-bbe4071c960d"
       ],
-      "ms.technology": "ews",
       "ms.tgt_pltfrm": "dotnet",
       "apiPlatform": "dotnet"
     },


### PR DESCRIPTION
This Pull Request was generated automatically as part of a global effort to improve metadata quality. Please review and merge this Pull Request within 5 days. If you have any questions or concerns about these metadata updates, please contact docs-allowlist-mgmt@microsoft.com. If you are not the correct contact for this content and repository, please notify Metadata-Management@microsoft.com.

Fixing[#2022-10-05?workitem=593828 Remove ms.technology value ews](https://dev.azure.com/ceapex/Engineering/_sprints/taskboard/Metadata/Engineering/2022-10-05?workitem=593828)

If this Pull Request is not merged within 14 days, it will be automatically merged by our system to ensure the timeliness of the metadata update.Please notify Metadata-Management@microsoft.com if you would like Pull Requests for metadata updates to merge automatically in future.

After you accept changes of metadata used in reports and they're merged, standard dashboards and reports will reflect new values, so you'll need to use new filter values.If you have any custom dashboards or Kusto queries, you might need to update those also.



**Why we make metadata updates**
Metadata updates are a normal part of business.For example, we update our metadata to reflect a new product name when a product is rebranded.Metadata updates require content to be updated because some metadata values(slugs) are included in the content(YAML header).
For metadata used internally, these updates make reports cleaner, easier to use, more consistent, and more reflective of current business.For metadata exposed to Learn Platform users, these updates ensure our users are exposed to up-to-date information consistent with their overall Microsoft experience.

**Frequently Asked Questions**
Why does this Pull Request appear to be made by the Repository Owner? We open Pull Requests two different ways.For Git Repos with a permissioned Service Account, we open the request from our org's Service Account.For Git Repos that we either do not have Service Account permission for or the repo is in Azure Dev Ops(ADO) we are able to open the Pull Requests in an automated way, but only with the PR creator as the Repo owner.